### PR TITLE
Cosmos claim check

### DIFF
--- a/datadog-core-sdk-otel.json
+++ b/datadog-core-sdk-otel.json
@@ -1,0 +1,1031 @@
+{
+  "title": "Temporal Core SDK (OTel) Metrics",
+  "description": "Dashboard for monitoring Temporal .NET Core SDK metrics via OpenTelemetry - converted from Grafana",
+  "template_variables": [
+    {
+      "name": "namespace",
+      "prefix": "namespace",
+      "available_values": [],
+      "default": "*"
+    },
+    {
+      "name": "service",
+      "prefix": "service",
+      "available_values": [],
+      "default": "*"
+    }
+  ],
+  "widgets": [
+    {
+      "id": 1,
+      "definition": {
+        "type": "note",
+        "content": "## CPU / Memory\n\nMetrics from the Temporal SDK should be complemented with the workers' CPU and memory usage statistics.",
+        "background_color": "blue",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      },
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "width": 12,
+        "height": 2
+      }
+    },
+    {
+      "id": 2,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:temporal_request{namespace:$namespace} by {namespace}.as_rate()",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "sum:temporal_request{namespace:$namespace} by {namespace}.as_rate()",
+                "alias_name": "[request] namespace: {{namespace.name}}"
+              }
+            ]
+          },
+          {
+            "q": "sum:temporal_request_failure{namespace:$namespace} by {namespace}.as_rate()",
+            "display_type": "line",
+            "style": {
+              "palette": "warm",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "sum:temporal_request_failure{namespace:$namespace} by {namespace}.as_rate()",
+                "alias_name": "[failure] namespace: {{namespace.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "RPC Requests Vs Failures",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto",
+        "yaxis": {
+          "scale": "linear",
+          "label": "",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        }
+      },
+      "layout": {
+        "x": 0,
+        "y": 2,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 3,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:temporal_request_failure{namespace:$namespace} by {namespace,operation}.as_rate()",
+            "display_type": "line",
+            "style": {
+              "palette": "warm",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "sum:temporal_request_failure{namespace:$namespace} by {namespace,operation}.as_rate()",
+                "alias_name": "namespace: {{namespace.name}}; operation: {{operation.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "RPC Failures Per Operation",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto"
+      },
+      "layout": {
+        "x": 6,
+        "y": 2,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 4,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:temporal_request{namespace:$namespace} by {namespace,operation}.as_rate()",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "sum:temporal_request{namespace:$namespace} by {namespace,operation}.as_rate()",
+                "alias_name": "namespace: {{namespace.name}}; operation: {{operation.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "RPC Requests Per Operation",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto"
+      },
+      "layout": {
+        "x": 0,
+        "y": 5,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 5,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "p95:temporal_request_latency{namespace:$namespace} by {namespace,operation}",
+            "display_type": "line",
+            "style": {
+              "palette": "purple",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "p95:temporal_request_latency{namespace:$namespace} by {namespace,operation}",
+                "alias_name": "namespace: {{namespace.name}}; operation: {{operation.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "RPC Latencies (p95)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto",
+        "yaxis": {
+          "scale": "linear",
+          "label": "milliseconds",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        }
+      },
+      "layout": {
+        "x": 6,
+        "y": 5,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 6,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:temporal_long_request_failure{namespace:$namespace} by {namespace,operation}.as_rate()",
+            "display_type": "line",
+            "style": {
+              "palette": "warm",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "sum:temporal_long_request_failure{namespace:$namespace} by {namespace,operation}.as_rate()",
+                "alias_name": "namespace: {{namespace.name}}; operation: {{operation.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Long RPC Failures Per Operation",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto"
+      },
+      "layout": {
+        "x": 0,
+        "y": 8,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 7,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "p95:temporal_long_request_latency{namespace:$namespace} by {namespace,operation}",
+            "display_type": "line",
+            "style": {
+              "palette": "purple",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "p95:temporal_long_request_latency{namespace:$namespace} by {namespace,operation}",
+                "alias_name": "namespace: {{namespace.name}}; operation: {{operation.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Long RPC Latencies (p95)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto",
+        "yaxis": {
+          "scale": "linear",
+          "label": "milliseconds",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        }
+      },
+      "layout": {
+        "x": 6,
+        "y": 8,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 8,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:temporal_workflow_completed{namespace:$namespace} by {namespace,workflow_type}.as_rate()",
+            "display_type": "line",
+            "style": {
+              "palette": "green",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "sum:temporal_workflow_completed{namespace:$namespace} by {namespace,workflow_type}.as_rate()",
+                "alias_name": "namespace: {{namespace.name}}; WorkflowType: {{workflow_type.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Workflow Completion",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto"
+      },
+      "layout": {
+        "x": 0,
+        "y": 11,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 9,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "p95:temporal_workflow_endtoend_latency{namespace:$namespace} by {namespace,workflow_type}",
+            "display_type": "line",
+            "style": {
+              "palette": "purple",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "p95:temporal_workflow_endtoend_latency{namespace:$namespace} by {namespace,workflow_type}",
+                "alias_name": "namespace: {{namespace.name}}; WorkflowType: {{workflow_type.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Workflow End-To-End Latencies",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto",
+        "yaxis": {
+          "scale": "linear",
+          "label": "milliseconds",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        }
+      },
+      "layout": {
+        "x": 6,
+        "y": 11,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 10,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:temporal_workflow_failed{namespace:$namespace} by {namespace,workflow_type}.as_rate()",
+            "display_type": "line",
+            "style": {
+              "palette": "warm",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "sum:temporal_workflow_failed{namespace:$namespace} by {namespace,workflow_type}.as_rate()",
+                "alias_name": "namespace: {{namespace.name}}; WorkflowType: {{workflow_type.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Workflow Failures By Type",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto"
+      },
+      "layout": {
+        "x": 0,
+        "y": 14,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 11,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:temporal_workflow_task_queue_poll_succeed{namespace:$namespace} by {namespace,task_queue}.as_rate()",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "sum:temporal_workflow_task_queue_poll_succeed{namespace:$namespace} by {namespace,task_queue}.as_rate()",
+                "alias_name": "namespace: {{namespace.name}}; task_queue: {{task_queue.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Workflow Task Throughput",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto"
+      },
+      "layout": {
+        "x": 6,
+        "y": 14,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 12,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "p95:temporal_workflow_task_schedule_to_start_latency{namespace:$namespace} by {namespace,task_queue}",
+            "display_type": "line",
+            "style": {
+              "palette": "purple",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "p95:temporal_workflow_task_schedule_to_start_latency{namespace:$namespace} by {namespace,task_queue}",
+                "alias_name": "namespace: {{namespace.name}}; task_queue: {{task_queue.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Workflow Task Schedule To Start (p95)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto",
+        "yaxis": {
+          "scale": "linear",
+          "label": "milliseconds",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        }
+      },
+      "layout": {
+        "x": 0,
+        "y": 17,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 13,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:temporal_workflow_task_execution_failed{namespace:$namespace} by {namespace,workflow_type}.as_rate()",
+            "display_type": "line",
+            "style": {
+              "palette": "warm",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "sum:temporal_workflow_task_execution_failed{namespace:$namespace} by {namespace,workflow_type}.as_rate()",
+                "alias_name": "namespace: {{namespace.name}}; workflow_type: {{workflow_type.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Workflow Task Failed",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto"
+      },
+      "layout": {
+        "x": 6,
+        "y": 17,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 14,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "p95:temporal_workflow_task_execution_latency{namespace:$namespace} by {namespace,workflow_type}",
+            "display_type": "line",
+            "style": {
+              "palette": "purple",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "p95:temporal_workflow_task_execution_latency{namespace:$namespace} by {namespace,workflow_type}",
+                "alias_name": "namespace: {{namespace.name}}; workflow_type: {{workflow_type.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Workflow Task Execution Latency (p95)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto",
+        "yaxis": {
+          "scale": "linear",
+          "label": "milliseconds",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        }
+      },
+      "layout": {
+        "x": 0,
+        "y": 20,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 15,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "p95:temporal_workflow_task_replay_latency{namespace:$namespace} by {namespace,workflow_type}",
+            "display_type": "line",
+            "style": {
+              "palette": "purple",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "p95:temporal_workflow_task_replay_latency{namespace:$namespace} by {namespace,workflow_type}",
+                "alias_name": "namespace: {{namespace.name}}; workflow_type: {{workflow_type.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Workflow Task Replay Latency (p95)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto",
+        "yaxis": {
+          "scale": "linear",
+          "label": "milliseconds",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        }
+      },
+      "layout": {
+        "x": 6,
+        "y": 20,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 16,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:temporal_workflow_task_queue_poll_empty{namespace:$namespace} by {namespace,task_queue}.as_rate()",
+            "display_type": "line",
+            "style": {
+              "palette": "grey",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "sum:temporal_workflow_task_queue_poll_empty{namespace:$namespace} by {namespace,task_queue}.as_rate()",
+                "alias_name": "namespace: {{namespace.name}}; task_queue: {{task_queue.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Workflow Task Empty Polls",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto"
+      },
+      "layout": {
+        "x": 0,
+        "y": 23,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 17,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:temporal_activity_schedule_to_start_latency.count{namespace:$namespace} by {namespace}.as_rate()",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "sum:temporal_activity_schedule_to_start_latency.count{namespace:$namespace} by {namespace}.as_rate()",
+                "alias_name": "namespace: {{namespace.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Activity Throughput",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto"
+      },
+      "layout": {
+        "x": 6,
+        "y": 23,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 18,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:temporal_activity_execution_failed{namespace:$namespace} by {namespace,activity_type}.as_rate()",
+            "display_type": "line",
+            "style": {
+              "palette": "warm",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "sum:temporal_activity_execution_failed{namespace:$namespace} by {namespace,activity_type}.as_rate()",
+                "alias_name": "namespace: {{namespace.name}}; activity_type: {{activity_type.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Activity Failed",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto"
+      },
+      "layout": {
+        "x": 0,
+        "y": 26,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 19,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "p95:temporal_activity_execution_latency{namespace:$namespace} by {namespace,activity_type}",
+            "display_type": "line",
+            "style": {
+              "palette": "purple",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "p95:temporal_activity_execution_latency{namespace:$namespace} by {namespace,activity_type}",
+                "alias_name": "namespace: {{namespace.name}}; activity_type: {{activity_type.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Activity Execution Latencies (p95)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto",
+        "yaxis": {
+          "scale": "linear",
+          "label": "milliseconds",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        }
+      },
+      "layout": {
+        "x": 6,
+        "y": 26,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 20,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:temporal_activity_poll_no_task{namespace:$namespace} by {namespace,task_queue}.as_rate()",
+            "display_type": "line",
+            "style": {
+              "palette": "grey",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "sum:temporal_activity_poll_no_task{namespace:$namespace} by {namespace,task_queue}.as_rate()",
+                "alias_name": "namespace: {{namespace.name}}; task_queue: {{task_queue.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Empty Activity Polls",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto"
+      },
+      "layout": {
+        "x": 0,
+        "y": 29,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 21,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "p95:temporal_activity_schedule_to_start_latency{namespace:$namespace} by {namespace,task_queue}",
+            "display_type": "line",
+            "style": {
+              "palette": "purple",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "p95:temporal_activity_schedule_to_start_latency{namespace:$namespace} by {namespace,task_queue}",
+                "alias_name": "namespace: {{namespace.name}}; task_queue: {{task_queue.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Activity Schedule To Start (p95)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto",
+        "yaxis": {
+          "scale": "linear",
+          "label": "milliseconds",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        }
+      },
+      "layout": {
+        "x": 6,
+        "y": 29,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 22,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "temporal_worker_task_slots_available{namespace:$namespace} by {namespace,worker_type}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "temporal_worker_task_slots_available{namespace:$namespace} by {namespace,worker_type}",
+                "alias_name": "namespace: {{namespace.name}}; worker_type: {{worker_type.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Slots Available",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto"
+      },
+      "layout": {
+        "x": 0,
+        "y": 32,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 23,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "temporal_worker_task_slots_used{namespace:$namespace} by {namespace,worker_type}",
+            "display_type": "line",
+            "style": {
+              "palette": "orange",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "temporal_worker_task_slots_used{namespace:$namespace} by {namespace,worker_type}",
+                "alias_name": "namespace: {{namespace.name}}; worker_type: {{worker_type.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Slots Used",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto"
+      },
+      "layout": {
+        "x": 6,
+        "y": 32,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 24,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "temporal_sticky_cache_size{namespace:$namespace} by {namespace}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "temporal_sticky_cache_size{namespace:$namespace} by {namespace}",
+                "alias_name": "namespace: {{namespace.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Sticky Cache Size",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto"
+      },
+      "layout": {
+        "x": 0,
+        "y": 35,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 25,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:temporal_sticky_cache_total_forced_eviction{namespace:$namespace} by {namespace}.as_rate()",
+            "display_type": "line",
+            "style": {
+              "palette": "warm",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "sum:temporal_sticky_cache_total_forced_eviction{namespace:$namespace} by {namespace}.as_rate()",
+                "alias_name": "namespace: {{namespace.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Sticky Cache Forced Eviction",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto"
+      },
+      "layout": {
+        "x": 6,
+        "y": 35,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 26,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:temporal_sticky_cache_hit{namespace:$namespace} by {namespace}.as_rate()",
+            "display_type": "line",
+            "style": {
+              "palette": "green",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "sum:temporal_sticky_cache_hit{namespace:$namespace} by {namespace}.as_rate()",
+                "alias_name": "namespace: {{namespace.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Sticky Cache Hit",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto"
+      },
+      "layout": {
+        "x": 0,
+        "y": 38,
+        "width": 6,
+        "height": 3
+      }
+    },
+    {
+      "id": 27,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:temporal_sticky_cache_miss{namespace:$namespace} by {namespace,task_queue}.as_rate()",
+            "display_type": "line",
+            "style": {
+              "palette": "orange",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "metadata": [
+              {
+                "expression": "sum:temporal_sticky_cache_miss{namespace:$namespace} by {namespace,task_queue}.as_rate()",
+                "alias_name": "namespace: {{namespace.name}}; task_queue: {{task_queue.name}}"
+              }
+            ]
+          }
+        ],
+        "title": "Sticky Cache Miss",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_columns": ["value", "avg", "sum", "min", "max"],
+        "legend_layout": "auto"
+      },
+      "layout": {
+        "x": 6,
+        "y": 38,
+        "width": 6,
+        "height": 3
+      }
+    }
+  ],
+  "layout_type": "ordered",
+  "is_read_only": false,
+  "notify_list": [],
+  "reflow_type": "fixed"
+}

--- a/dotnet/src/Temporal.Operations.Proxy/Cosmos/CosmosPayload.cs
+++ b/dotnet/src/Temporal.Operations.Proxy/Cosmos/CosmosPayload.cs
@@ -5,4 +5,6 @@ public class CosmosPayload()
     public string id { get; set; }
     public byte[] value { get; set; }
     public string temporalNamespace { get; set; }
+    
+    public int ttl { get; set; }
 }

--- a/dotnet/src/Temporal.Operations.Proxy/Cosmos/CosmosPayload.cs
+++ b/dotnet/src/Temporal.Operations.Proxy/Cosmos/CosmosPayload.cs
@@ -1,0 +1,8 @@
+namespace Temporal.Operations.Proxy.Cosmos;
+
+public class CosmosPayload()
+{
+    public string id { get; set; }
+    public byte[] value { get; set; }
+    public string temporalNamespace { get; set; }
+}

--- a/dotnet/src/Temporal.Operations.Proxy/Cosmos/CosmosPayloadCodec.cs
+++ b/dotnet/src/Temporal.Operations.Proxy/Cosmos/CosmosPayloadCodec.cs
@@ -32,7 +32,8 @@ public class CosmosPayloadCodec : ICodec<PayloadContext, byte[]>, ICodec<Payload
         {
             id=id, 
             value = value,
-            temporalNamespace = context.Namespace
+            temporalNamespace = context.Namespace,
+            ttl = 60 * 60 * 24 * 180 // 180 days TTL
         };
         // TODO janky async/sync mix
         _dataService.CreateItemAsync(cp,cp.temporalNamespace, CosmosContainerName).Wait();

--- a/dotnet/src/Temporal.Operations.Proxy/Cosmos/CosmosPayloadCodec.cs
+++ b/dotnet/src/Temporal.Operations.Proxy/Cosmos/CosmosPayloadCodec.cs
@@ -1,0 +1,121 @@
+using Google.Protobuf;
+using Microsoft.Azure.Cosmos;
+using Temporal.Operations.Proxy.Interfaces;
+using Temporal.Operations.Proxy.Models;
+
+namespace Temporal.Operations.Proxy.Cosmos;
+
+public class CosmosPayloadCodec : ICodec<PayloadContext, byte[]>, ICodec<PayloadContext, Temporalio.Api.Common.V1.Payload>
+{
+    private IDataService _dataService;
+
+    public CosmosPayloadCodec(IDataService dataService)
+    {
+        _dataService = dataService;
+    }
+    public const string CosmosDatabaseName = "temporal";
+    public const string CosmosContainerName = "payloads";
+    public const string CosmosPartitionKey = "/temporalNamespace";
+    public const string CosmosIdMetadataKey = "cosmos-id";
+    public const string EncodingMetadataOriginalKey = "encoding-original";
+    public const string EncodingMetadataKey = "encoding";
+    public const string EncodingMetadataValue = "claim/checked";
+    private static readonly ByteString EncodingMetadataValueByteString = ByteString.CopyFromUtf8(EncodingMetadataValue);
+    
+    public Temporalio.Api.Common.V1.Payload Encode(PayloadContext context, Temporalio.Api.Common.V1.Payload payload)
+    {
+        
+        // Cosmos requires a unique id for each item
+        var id = Guid.NewGuid().ToString();
+        var value = payload.Data.ToByteArray();
+        var cp = new CosmosPayload
+        {
+            id=id, 
+            value = value,
+            temporalNamespace = context.Namespace
+        };
+        // TODO janky async/sync mix
+        _dataService.CreateItemAsync(cp,cp.temporalNamespace, CosmosContainerName).Wait();
+        
+        var enc = new Temporalio.Api.Common.V1.Payload();
+        var encodingSwapped = false;
+        enc.Metadata.Add(CosmosIdMetadataKey, ByteString.CopyFromUtf8(id));
+        foreach (var kvp in payload.Metadata)
+        {
+            if (kvp.Key == EncodingMetadataKey)
+            {
+                enc.Metadata[EncodingMetadataOriginalKey] = kvp.Value;
+                enc.Metadata[EncodingMetadataKey] = EncodingMetadataValueByteString;
+                encodingSwapped = true;
+            }
+            else
+            {
+                enc.Metadata[kvp.Key] = kvp.Value;
+            }
+        }
+
+        if (!encodingSwapped)
+        {
+            enc.Metadata[EncodingMetadataKey] = EncodingMetadataValueByteString;
+        }
+        
+        enc.Data = ByteString.CopyFromUtf8("who moved my cheese?");
+        return enc;
+    }
+
+    public Temporalio.Api.Common.V1.Payload Decode(PayloadContext context, Temporalio.Api.Common.V1.Payload payload)
+    {
+        
+        // Remove encryption metadata and restore original encoding
+        if (!payload.Metadata[EncodingMetadataKey].Equals(EncodingMetadataValueByteString))
+        {
+            return payload;
+        }
+        
+        if (!payload.Metadata.TryGetValue(CosmosIdMetadataKey, out var idBytes))
+        {
+            throw new InvalidOperationException($"Missing {CosmosIdMetadataKey} metadata");
+        }
+
+        var dec = new Temporalio.Api.Common.V1.Payload();
+        foreach (var kvp in payload.Metadata)
+        {
+            switch (kvp.Key)
+            {
+                case EncodingMetadataKey:
+                case CosmosIdMetadataKey:
+                    // do not include these metadata keys
+                    continue;
+                case EncodingMetadataOriginalKey:
+                    dec.Metadata[EncodingMetadataKey] = payload.Metadata[EncodingMetadataOriginalKey];
+                    break;
+                default:
+                    // preserve custom metadata
+                    dec.Metadata[kvp.Key] = kvp.Value;
+                    break;
+            }
+        }
+        
+        var id = idBytes.ToStringUtf8();
+        var cosmosPayload = _dataService.GetItemAsync<CosmosPayload>(id, context.Namespace, CosmosContainerName).Result;
+        dec.Data = ByteString.CopyFrom(cosmosPayload.value);
+        
+        return dec;
+    }
+
+    public byte[] Encode(PayloadContext context, byte[] value)
+    {
+        var payload = Temporalio.Api.Common.V1.Payload.Parser.ParseFrom(value);
+        
+        var encoded = Encode(context, payload);
+
+        return encoded.ToByteArray();    
+    }
+
+    public byte[] Decode(PayloadContext context, byte[] value)
+    {
+        var payload = Temporalio.Api.Common.V1.Payload.Parser.ParseFrom(value);
+        var decoded = Decode(context, payload);
+        return decoded.ToByteArray();
+    }
+}

--- a/dotnet/src/Temporal.Operations.Proxy/Cosmos/DataService.cs
+++ b/dotnet/src/Temporal.Operations.Proxy/Cosmos/DataService.cs
@@ -1,0 +1,66 @@
+using Microsoft.Azure.Cosmos;
+
+namespace Temporal.Operations.Proxy.Cosmos;
+
+public class DataService : IDataService
+{
+    private readonly CosmosClient _cosmosClient;
+    private readonly string _databaseName;
+
+    public DataService(CosmosClient cosmosClient, IConfiguration configuration)
+    {
+        _cosmosClient = cosmosClient;
+        _databaseName = configuration["CosmosDB:DatabaseName"] ?? "DefaultDatabase";
+    }
+
+    public async Task<T> GetItemAsync<T>(string id, string partitionKey, string containerName)
+    {
+        try
+        {
+            var container = _cosmosClient.GetContainer(_databaseName, containerName);
+            var response = await container.ReadItemAsync<T>(id, new PartitionKey(partitionKey));
+            return response.Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return default(T);
+        }
+    }
+
+    public async Task<T> CreateItemAsync<T>(T item, string partitionKey, string containerName)
+    {
+        var container = _cosmosClient.GetContainer(_databaseName, containerName);
+        var response = await container.CreateItemAsync(item, new PartitionKey(partitionKey));
+        return response.Resource;
+    }
+
+    public async Task<T> UpdateItemAsync<T>(string id, T item, string partitionKey, string containerName)
+    {
+        var container = _cosmosClient.GetContainer(_databaseName, containerName);
+        var response = await container.ReplaceItemAsync(item, id, new PartitionKey(partitionKey));
+        return response.Resource;
+    }
+
+    public async Task DeleteItemAsync(string id, string partitionKey, string containerName)
+    {
+        var container = _cosmosClient.GetContainer(_databaseName, containerName);
+        await container.DeleteItemAsync<object>(id, new PartitionKey(partitionKey));
+    }
+
+    public async Task<IEnumerable<T>> QueryItemsAsync<T>(string query, string containerName)
+    {
+        var container = _cosmosClient.GetContainer(_databaseName, containerName);
+        var queryDefinition = new QueryDefinition(query);
+        
+        var results = new List<T>();
+        using var feedIterator = container.GetItemQueryIterator<T>(queryDefinition);
+        
+        while (feedIterator.HasMoreResults)
+        {
+            var response = await feedIterator.ReadNextAsync();
+            results.AddRange(response.ToList());
+        }
+        
+        return results;
+    }
+}

--- a/dotnet/src/Temporal.Operations.Proxy/Cosmos/DataService.cs
+++ b/dotnet/src/Temporal.Operations.Proxy/Cosmos/DataService.cs
@@ -30,7 +30,10 @@ public class DataService : IDataService
     public async Task<T> CreateItemAsync<T>(T item, string partitionKey, string containerName)
     {
         var container = _cosmosClient.GetContainer(_databaseName, containerName);
-        var response = await container.CreateItemAsync(item, new PartitionKey(partitionKey));
+        var response = await container.CreateItemAsync(
+            item, 
+            new PartitionKey(partitionKey), new ItemRequestOptions{}
+            );
         return response.Resource;
     }
 

--- a/dotnet/src/Temporal.Operations.Proxy/Cosmos/IDataService.cs
+++ b/dotnet/src/Temporal.Operations.Proxy/Cosmos/IDataService.cs
@@ -1,0 +1,10 @@
+namespace Temporal.Operations.Proxy.Cosmos;
+
+public interface IDataService
+{
+    Task<T> GetItemAsync<T>(string id, string partitionKey, string containerName);
+    Task<T> CreateItemAsync<T>(T item, string partitionKey, string containerName);
+    Task<T> UpdateItemAsync<T>(string id, T item, string partitionKey, string containerName);
+    Task DeleteItemAsync(string id, string partitionKey, string containerName);
+    Task<IEnumerable<T>> QueryItemsAsync<T>(string query, string containerName);
+}

--- a/dotnet/src/Temporal.Operations.Proxy/Program.cs
+++ b/dotnet/src/Temporal.Operations.Proxy/Program.cs
@@ -1,8 +1,10 @@
+using System.Diagnostics;
 using System.Security.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Options;
 using Temporal.Operations.Proxy.Configuration;
 using Temporal.Operations.Proxy.Interfaces;
@@ -91,6 +93,23 @@ builder.Services.AddGrpc();
 // app.MapGrpcReflectionService();
 builder.Logging.AddFilter("Microsoft.AspNetCore.Server.Kestrel", LogLevel.Information);
 builder.Logging.AddFilter("Yarp.ReverseProxy.Forwarder.HttpForwarder", LogLevel.Error);
+
+
+// Cosmos configuration
+// Add CosmosDB client
+builder.Services.AddSingleton<CosmosClient>(serviceProvider =>
+{
+    var configuration = serviceProvider.GetService<IConfiguration>();
+    Debug.Assert(configuration != null, nameof(configuration) + " != null");
+    var connectionString = configuration.GetConnectionString("CosmosDB");
+    
+    // Alternative: Use account endpoint and key
+    // var endpoint = configuration["CosmosDB:Endpoint"];
+    // var key = configuration["CosmosDB:Key"];
+    // return new CosmosClient(endpoint, key);
+    
+    return new CosmosClient(connectionString);
+});
 
 var app = builder.Build();
 // Validate configuration on startup

--- a/dotnet/src/Temporal.Operations.Proxy/Program.cs
+++ b/dotnet/src/Temporal.Operations.Proxy/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Options;
 using Temporal.Operations.Proxy.Configuration;
+using Temporal.Operations.Proxy.Cosmos;
 using Temporal.Operations.Proxy.Interfaces;
 using Temporal.Operations.Proxy.Middleware;
 using Temporal.Operations.Proxy.Models;
@@ -74,7 +75,8 @@ builder.Services.AddSingleton<AesByteEncryptor>(_ => new AesByteEncryptor());
 builder.Services.AddSingleton<IEncrypt>(p => p.GetRequiredService<AesByteEncryptor>());
 builder.Services.AddSingleton<IAddEncryptionKey>(p => p.GetRequiredService<AesByteEncryptor>());
 
-builder.Services.AddSingleton<ICodec<PayloadContext, byte[]>, CryptPayloadCodec>();
+// encryption direction
+// builder.Services.AddSingleton<ICodec<PayloadContext, byte[]>, CryptPayloadCodec>();
 builder.Services.AddSingleton<ICodec<MessageContext,byte[]>, MessageCodec>();
 
 // Register Temporal API descriptor services
@@ -110,6 +112,9 @@ builder.Services.AddSingleton<CosmosClient>(serviceProvider =>
     
     return new CosmosClient(connectionString);
 });
+
+builder.Services.AddSingleton<IDataService, DataService>();
+builder.Services.AddSingleton<ICodec<PayloadContext, byte[]>, CosmosPayloadCodec>();
 
 var app = builder.Build();
 // Validate configuration on startup

--- a/dotnet/src/Temporal.Operations.Proxy/Temporal.Operations.Proxy.csproj
+++ b/dotnet/src/Temporal.Operations.Proxy/Temporal.Operations.Proxy.csproj
@@ -11,6 +11,7 @@
         <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />
         <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.71.0" />
         <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
+        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.52.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Temporalio" Version="1.7.0" />
         <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />

--- a/dotnet/src/Temporal.Operations.Proxy/Temporal.Operations.Proxy.csproj
+++ b/dotnet/src/Temporal.Operations.Proxy/Temporal.Operations.Proxy.csproj
@@ -13,6 +13,7 @@
         <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
         <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.52.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Temporalio" Version="1.7.0" />
         <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
     </ItemGroup>

--- a/dotnet/src/Temporal.Operations.Proxy/appsettings.Development.json
+++ b/dotnet/src/Temporal.Operations.Proxy/appsettings.Development.json
@@ -56,7 +56,7 @@
     "EncodeSearchAttributes" : false
   },
   "ConnectionStrings": {
-    "CosmosDB": "AccountEndpoint=https://mnichols.documents.azure.com:443/;AccountKey={REDACTED};"
+    "CosmosDB": "{REDACTED};"
   },
   "CosmosDB": {
     "Endpoint": "https://mnichols.documents.azure.com:443/",

--- a/dotnet/src/Temporal.Operations.Proxy/appsettings.Development.json
+++ b/dotnet/src/Temporal.Operations.Proxy/appsettings.Development.json
@@ -54,6 +54,13 @@
   "TemporalApi": {
     "DescriptorFilePath": "../../../generated/temporal-api.binpb",
     "EncodeSearchAttributes" : false
+  },
+  "ConnectionStrings": {
+    "CosmosDB": "AccountEndpoint=https://your-account.documents.azure.com:443/;AccountKey=your-key;"
+  },
+  "CosmosDB": {
+    "Endpoint": "https://your-account.documents.azure.com:443/",
+    "Key": "your-key",
+    "DatabaseName": "YarpProxyDB"
   }
-
 }

--- a/dotnet/src/Temporal.Operations.Proxy/appsettings.Development.json
+++ b/dotnet/src/Temporal.Operations.Proxy/appsettings.Development.json
@@ -56,11 +56,11 @@
     "EncodeSearchAttributes" : false
   },
   "ConnectionStrings": {
-    "CosmosDB": "AccountEndpoint=https://your-account.documents.azure.com:443/;AccountKey=your-key;"
+    "CosmosDB": "AccountEndpoint=https://mnichols.documents.azure.com:443/;AccountKey={REDACTED};"
   },
   "CosmosDB": {
-    "Endpoint": "https://your-account.documents.azure.com:443/",
-    "Key": "your-key",
-    "DatabaseName": "YarpProxyDB"
+    "Endpoint": "https://mnichols.documents.azure.com:443/",
+    "Key": "{REDACTED}",
+    "DatabaseName": "temporal"
   }
 }

--- a/dotnet/src/Temporal.Operations.Proxy/appsettings.json
+++ b/dotnet/src/Temporal.Operations.Proxy/appsettings.json
@@ -54,6 +54,14 @@
   "TemporalApi": {
     "DescriptorFilePath": "../../../generated/temporal-api.binpb",
     "EncodeSearchAttributes" : false
+  },
+  "ConnectionStrings": {
+    "CosmosDB": "{REDACTED}"
+  },
+  "CosmosDB": {
+    "Endpoint": "{REDACTED}",
+    "Key": "{REDACTED}",
+    "DatabaseName": "temporal"
   }
 
 }

--- a/dotnet/src/Temporal.Operations.Proxy/appsettings.json
+++ b/dotnet/src/Temporal.Operations.Proxy/appsettings.json
@@ -63,5 +63,4 @@
     "Key": "{REDACTED}",
     "DatabaseName": "temporal"
   }
-
 }


### PR DESCRIPTION
Azure CosmosDB can be utilized to store payloads by implementing `ICodec<PayloadContext, byte[]>` interface. 
This is handy for doing Claim Check pattern with payloads to allow data to be swapped out on the way to/fro Temporal service.
